### PR TITLE
Implement simple football lineup draft UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,38 +1,33 @@
-.App {
-  text-align: center;
+body {
+  margin: 0;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.field {
+  background-color: #1e7a1e;
+  height: 100vh;
   display: flex;
   flex-direction: column;
+  justify-content: space-around;
+  padding: 20px 0;
+  box-sizing: border-box;
+}
+
+.row {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.position {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px dashed #fff;
+  color: #fff;
+  display: flex;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  font-size: 24px;
+  cursor: pointer;
+  background-color: rgba(255, 255, 255, 0.2);
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,23 +1,36 @@
-import logo from './logo.svg';
+import React, { useState } from 'react';
 import './App.css';
 
 function App() {
+  const formation = [1, 4, 4, 2];
+  const [players, setPlayers] = useState(
+    formation.map(count => Array(count).fill(''))
+  );
+
+  const handleAddPlayer = (row, index) => {
+    const name = prompt('Enter player name:');
+    if (name) {
+      const updated = players.map(r => [...r]);
+      updated[row][index] = name;
+      setPlayers(updated);
+    }
+  };
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div className="field">
+      {players.map((row, rowIndex) => (
+        <div className="row" key={rowIndex}>
+          {row.map((player, posIndex) => (
+            <div
+              key={posIndex}
+              className="position"
+              onClick={() => handleAddPlayer(rowIndex, posIndex)}
+            >
+              {player || '+'}
+            </div>
+          ))}
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders lineup positions', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const plusElements = screen.getAllByText('+');
+  expect(plusElements.length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- build lineup UI with green soccer field
- let players be added with a prompt by clicking '+'' placeholders
- update CSS for field layout
- update test to reflect new UI

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f88e8e9048326ac30d7831b82a64a