### PR TITLE
Add player search using TheSportsDB

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,44 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+import httpx
 
 app = FastAPI()
+
+# Enable CORS for local development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")
 async def root():
     return {"message": "Hello World"}
+
+
+API_URL = "https://www.thesportsdb.com/api/v1/json/3/searchplayers.php"
+
+
+@app.get("/players")
+async def get_players(search: str):
+    """Fetch player names from the free TheSportsDB API."""
+    params = {"p": search}
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(API_URL, params=params, timeout=10)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    data = response.json()
+    names = []
+    for player in data.get("player", []) or []:
+        name = player.get("strPlayer")
+        if name:
+            names.append(name)
+    return {"players": names}
 
 
 # # Allow React dev server on localhost:3000

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,3 +31,36 @@ body {
   cursor: pointer;
   background-color: rgba(255, 255, 255, 0.2);
 }
+
+.player-search {
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  padding: 20px;
+  border: 1px solid #ccc;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.player-search input {
+  width: 200px;
+  padding: 5px;
+  margin-bottom: 10px;
+}
+
+.player-search ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.player-search li {
+  padding: 5px 0;
+  cursor: pointer;
+}
+
+.player-search li:hover {
+  background: #eee;
+}


### PR DESCRIPTION
## Summary
- add `/players` endpoint in FastAPI that queries the free TheSportsDB API
- enable CORS for dev use
- add player search modal to React UI
- fetch player suggestions from backend and filter out already selected names
- style player search popup
- provide backend requirements file

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8a55bb3883269a89a41720b31866