### PR TITLE
Improve performance and UX

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,13 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import httpx
+import time
 
 app = FastAPI()
+
+player_search_cache = {}
+player_detail_cache = {}
+CACHE_TTL = 3600
 
 # Enable CORS for local development
 app.add_middleware(
@@ -11,6 +16,16 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.on_event("startup")
+async def startup_event():
+    app.state.client = httpx.AsyncClient()
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    await app.state.client.aclose()
 
 
 @app.get("/")
@@ -24,11 +39,15 @@ API_URL = "https://www.thesportsdb.com/api/v1/json/3/searchplayers.php"
 @app.get("/players")
 async def get_players(search: str):
     """Fetch player names from the free TheSportsDB API."""
+    now = time.time()
+    cached = player_search_cache.get(search.lower())
+    if cached and now - cached[0] < CACHE_TTL:
+        return {"players": cached[1]}
+
     params = {"p": search}
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(API_URL, params=params, timeout=10)
-            response.raise_for_status()
+        response = await app.state.client.get(API_URL, params=params, timeout=10)
+        response.raise_for_status()
     except httpx.HTTPError as exc:
         raise HTTPException(status_code=502, detail=str(exc))
 
@@ -38,17 +57,23 @@ async def get_players(search: str):
         name = player.get("strPlayer")
         if name:
             names.append(name)
+
+    player_search_cache[search.lower()] = (now, names)
     return {"players": names}
 
 
 @app.get("/player")
 async def get_player_details(name: str):
     """Fetch details for a specific player."""
+    now = time.time()
+    cached = player_detail_cache.get(name.lower())
+    if cached and now - cached[0] < CACHE_TTL:
+        return cached[1]
+
     params = {"p": name}
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(API_URL, params=params, timeout=10)
-            response.raise_for_status()
+        response = await app.state.client.get(API_URL, params=params, timeout=10)
+        response.raise_for_status()
     except httpx.HTTPError as exc:
         raise HTTPException(status_code=502, detail=str(exc))
 
@@ -57,12 +82,14 @@ async def get_player_details(name: str):
     if not player_list:
         raise HTTPException(status_code=404, detail="Player not found")
     player = player_list[0]
-    return {
+    result = {
         "name": player.get("strPlayer"),
         "nationality": player.get("strNationality"),
         "club": player.get("strTeam"),
         "league": player.get("strLeague"),
     }
+    player_detail_cache[name.lower()] = (now, result)
+    return result
 
 
 # # Allow React dev server on localhost:3000

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -32,6 +32,11 @@ body {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
+.position.selected {
+  background-color: rgba(255, 255, 255, 0.4);
+  border-style: solid;
+}
+
 .player-search {
   position: fixed;
   top: 20%;

--- a/frontend/src/useDebounce.js
+++ b/frontend/src/useDebounce.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export default function useDebounce(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- cache API calls in backend for faster repeated searches
- reuse a single HTTP client across requests
- add debounced search in the React UI
- show loading indicator and "no players" message
- highlight selected lineup position

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8db744bc83268ac22d99cbba3b23