### PR TITLE
Fix chemistry logic and display total chemistry

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -37,6 +37,13 @@ body {
   border-style: solid;
 }
 
+.total-chemistry {
+  color: #fff;
+  text-align: center;
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+
 .player-search {
   position: fixed;
   top: 20%;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ function App() {
   const [chemistry, setChemistry] = useState(
     formation.map(count => Array(count).fill(0))
   );
+  const [totalChem, setTotalChem] = useState(0);
   const [selectedPos, setSelectedPos] = useState(null);
   const [query, setQuery] = useState('');
   const [suggestions, setSuggestions] = useState([]);
@@ -54,7 +55,9 @@ function App() {
   }, [debouncedQuery, selectedPos, players]);
 
   useEffect(() => {
-    setChemistry(calculateChemistry(players));
+    const newChem = calculateChemistry(players);
+    setChemistry(newChem);
+    setTotalChem(newChem.flat().reduce((sum, c) => sum + c, 0));
   }, [players]);
 
   const handleSelect = async (name) => {
@@ -76,6 +79,7 @@ function App() {
 
   return (
     <div className="field">
+      <div className="total-chemistry">{totalChem}/33</div>
       {players.map((row, rowIndex) => (
         <div className="row" key={rowIndex}>
           {row.map((player, posIndex) => (

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -13,3 +13,16 @@ test('chemistry zero for empty lineup', () => {
   const result = calculateChemistry(formation);
   expect(result.flat().every(c => c === 0)).toBe(true);
 });
+
+test('club chemistry reaches 3 at seven players', () => {
+  const players = [
+    Array.from({ length: 7 }, (_, i) => ({
+      name: `p${i}`,
+      club: 'A',
+      league: `L${i}`,
+      nationality: `N${i}`,
+    }))
+  ];
+  const result = calculateChemistry(players);
+  expect(result[0].every(c => c === 3)).toBe(true);
+});

--- a/frontend/src/chemistry.js
+++ b/frontend/src/chemistry.js
@@ -10,23 +10,24 @@ export function calculateChemistry(players) {
     if (p.nationality) nations[p.nationality] = (nations[p.nationality] || 0) + 1;
   });
 
+  // New chemistry rules
   const clubContribution = count => {
-    if (count >= 4) return 3;
-    if (count >= 3) return 2;
+    if (count >= 7) return 3;
+    if (count >= 4) return 2;
     if (count >= 2) return 1;
     return 0;
   };
 
   const leagueContribution = count => {
-    if (count >= 7) return 3;
+    if (count >= 8) return 3;
     if (count >= 5) return 2;
     if (count >= 3) return 1;
     return 0;
   };
 
   const nationContribution = count => {
-    if (count >= 6) return 3;
-    if (count >= 4) return 2;
+    if (count >= 8) return 3;
+    if (count >= 5) return 2;
     if (count >= 2) return 1;
     return 0;
   };


### PR DESCRIPTION
## Summary
- update chemistry calculation rules
- show total chemistry in the UI
- style the total chemistry section
- add a unit test for new chemistry rule

## Testing
- `npm test --silent -- -w=1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8fe2e8e0832681b2f1fb10e10313