### PR TITLE
Fix chemistry calculation and add debugging info

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,8 @@ app = FastAPI()
 
 player_search_cache = {}
 player_detail_cache = {}
-CACHE_TTL = 3600
+SEARCH_CACHE_TTL = 3600
+DETAIL_CACHE_TTL = 60  # keep player details fresh
 
 # Enable CORS for local development
 app.add_middleware(
@@ -41,7 +42,7 @@ async def get_players(search: str):
     """Fetch player names from the free TheSportsDB API."""
     now = time.time()
     cached = player_search_cache.get(search.lower())
-    if cached and now - cached[0] < CACHE_TTL:
+    if cached and now - cached[0] < SEARCH_CACHE_TTL:
         return {"players": cached[1]}
 
     params = {"p": search}
@@ -67,7 +68,7 @@ async def get_player_details(name: str):
     """Fetch details for a specific player."""
     now = time.time()
     cached = player_detail_cache.get(name.lower())
-    if cached and now - cached[0] < CACHE_TTL:
+    if cached and now - cached[0] < DETAIL_CACHE_TTL:
         return cached[1]
 
     params = {"p": name}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -76,3 +76,12 @@ body {
 .player-search li:hover {
   background: #eee;
 }
+
+.toggle-info {
+  margin: 0 auto 10px auto;
+  padding: 5px 10px;
+}
+
+.info {
+  font-size: 12px;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,7 @@ function App() {
   const [query, setQuery] = useState('');
   const [suggestions, setSuggestions] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
 
   const debouncedQuery = useDebounce(query, 300);
 
@@ -80,6 +81,9 @@ function App() {
   return (
     <div className="field">
       <div className="total-chemistry">{totalChem}/33</div>
+      <button className="toggle-info" onClick={() => setShowInfo(!showInfo)}>
+        {showInfo ? 'Hide info' : 'Show info'}
+      </button>
       {players.map((row, rowIndex) => (
         <div className="row" key={rowIndex}>
           {row.map((player, posIndex) => (
@@ -94,7 +98,18 @@ function App() {
               }`}
               onClick={() => handleAddPlayer(rowIndex, posIndex)}
             >
-              {player ? `${player.name} (${chemistry[rowIndex][posIndex]})` : '+'}
+              {player ? (
+                <>
+                  {player.name} ({chemistry[rowIndex][posIndex]})
+                  {showInfo && (
+                    <div className="info">
+                      {player.club || 'Unknown'} / {player.nationality || 'Unknown'}
+                    </div>
+                  )}
+                </>
+              ) : (
+                '+'
+              )}
             </div>
           ))}
         </div>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -26,3 +26,15 @@ test('club chemistry reaches 3 at seven players', () => {
   const result = calculateChemistry(players);
   expect(result[0].every(c => c === 3)).toBe(true);
 });
+
+test('club names are counted case-insensitively', () => {
+  const players = [
+    [
+      { name: 'p1', club: 'Real', league: 'L1', nationality: 'N1' },
+      { name: 'p2', club: 'real', league: 'L2', nationality: 'N2' },
+    ],
+  ];
+  const result = calculateChemistry(players);
+  expect(result[0][0]).toBe(1);
+  expect(result[0][1]).toBe(1);
+});

--- a/frontend/src/chemistry.js
+++ b/frontend/src/chemistry.js
@@ -3,11 +3,22 @@ export function calculateChemistry(players) {
   const leagues = {};
   const nations = {};
 
+  const norm = str => (str ? str.trim().toLowerCase() : '');
+
   players.flat().forEach(p => {
     if (!p) return;
-    if (p.club) clubs[p.club] = (clubs[p.club] || 0) + 1;
-    if (p.league) leagues[p.league] = (leagues[p.league] || 0) + 1;
-    if (p.nationality) nations[p.nationality] = (nations[p.nationality] || 0) + 1;
+    if (p.club) {
+      const key = norm(p.club);
+      clubs[key] = (clubs[key] || 0) + 1;
+    }
+    if (p.league) {
+      const key = norm(p.league);
+      leagues[key] = (leagues[key] || 0) + 1;
+    }
+    if (p.nationality) {
+      const key = norm(p.nationality);
+      nations[key] = (nations[key] || 0) + 1;
+    }
   });
 
   // Chemistry rules based on counts of matching attributes
@@ -35,10 +46,13 @@ export function calculateChemistry(players) {
   return players.map(row =>
     row.map(p => {
       if (!p) return 0;
+      const clubKey = norm(p.club);
+      const leagueKey = norm(p.league);
+      const nationKey = norm(p.nationality);
       const chem =
-        clubContribution(clubs[p.club] || 0) +
-        leagueContribution(leagues[p.league] || 0) +
-        nationContribution(nations[p.nationality] || 0);
+        clubContribution(clubs[clubKey] || 0) +
+        leagueContribution(leagues[leagueKey] || 0) +
+        nationContribution(nations[nationKey] || 0);
       return Math.min(3, chem);
     })
   );


### PR DESCRIPTION
## Summary
- normalize names in chemistry calculator to avoid case mismatch
- reduce caching of player details for fresher data
- allow toggling visibility of club/nationality on lineup
- add styles for toggle button and info text
- test case for case-insensitive club counting

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9375b6b88326815577552aa82076