### PR TITLE
Improve player display with images

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -120,6 +120,9 @@ async def get_player_details(name: str):
         "nationality": player.get("strNationality"),
         "club": player.get("strTeam"),
         "league": league,
+        "photo": player.get("strCutout")
+        or player.get("strThumb")
+        or player.get("strRender"),
     }
     player_detail_cache[name.lower()] = (now, result)
     return result

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -18,18 +18,45 @@ body {
   align-items: center;
 }
 
+.position-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 80px;
+  color: #fff;
+  text-align: center;
+}
+
 .position {
-  width: 60px;
-  height: 60px;
+  width: 80px;
+  height: 80px;
   border-radius: 50%;
   border: 2px dashed #fff;
-  color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 24px;
   cursor: pointer;
   background-color: rgba(255, 255, 255, 0.2);
+  background-size: cover;
+  background-position: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.chem-badge {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.player-name {
+  margin-top: 4px;
+  font-size: 12px;
 }
 
 .position.selected {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -87,28 +87,39 @@ function App() {
       {players.map((row, rowIndex) => (
         <div className="row" key={rowIndex}>
           {row.map((player, posIndex) => (
-            <div
-              key={posIndex}
-              className={`position ${
-                selectedPos &&
-                selectedPos.row === rowIndex &&
-                selectedPos.index === posIndex
-                  ? 'selected'
-                  : ''
-              }`}
-              onClick={() => handleAddPlayer(rowIndex, posIndex)}
-            >
-              {player ? (
+            <div className="position-container" key={posIndex}>
+              <div
+                className={`position ${
+                  selectedPos &&
+                  selectedPos.row === rowIndex &&
+                  selectedPos.index === posIndex
+                    ? 'selected'
+                    : ''
+                }`}
+                onClick={() => handleAddPlayer(rowIndex, posIndex)}
+                style={
+                  player && player.photo
+                    ? { backgroundImage: `url(${player.photo})` }
+                    : {}
+                }
+              >
+                {player && (
+                  <div className="chem-badge">
+                    {chemistry[rowIndex][posIndex]}
+                  </div>
+                )}
+                {!player && '+'}
+              </div>
+              {player && (
                 <>
-                  {player.name} ({chemistry[rowIndex][posIndex]})
+                  <div className="player-name">{player.name}</div>
                   {showInfo && (
                     <div className="info">
-                    {player.club || 'Unknown'} / {player.league || 'Unknown'} / {player.nationality || 'Unknown'}
+                      {player.club || 'Unknown'} / {player.league || 'Unknown'} /
+                      {player.nationality || 'Unknown'}
                     </div>
                   )}
                 </>
-              ) : (
-                '+'
               )}
             </div>
           ))}


### PR DESCRIPTION
## Summary
- include `photo` field in backend player details
- redesign player slots to show player images and names
- update styles for better visuals

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9d7866808326b1462c19f8bb0c9c