### PR TITLE
Update lineup info and layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -109,6 +109,13 @@ body {
   padding: 5px 10px;
 }
 
-.info {
+.info-list {
   font-size: 12px;
+  margin: 4px 0;
+  padding-left: 16px;
+  text-align: left;
+}
+
+.info-list li {
+  margin: 2px 0;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,8 @@ function App() {
 
   const debouncedQuery = useDebounce(query, 300);
 
+  const displayRows = players.slice().reverse();
+
   const handleAddPlayer = (row, index) => {
     setSelectedPos({ row, index });
     setQuery('');
@@ -84,9 +86,11 @@ function App() {
       <button className="toggle-info" onClick={() => setShowInfo(!showInfo)}>
         {showInfo ? 'Hide info' : 'Show info'}
       </button>
-      {players.map((row, rowIndex) => (
-        <div className="row" key={rowIndex}>
-          {row.map((player, posIndex) => (
+      {displayRows.map((row, displayIndex) => {
+        const rowIndex = players.length - 1 - displayIndex;
+        return (
+          <div className="row" key={rowIndex}>
+            {row.map((player, posIndex) => (
             <div className="position-container" key={posIndex}>
               <div
                 className={`position ${
@@ -114,17 +118,20 @@ function App() {
                 <>
                   <div className="player-name">{player.name}</div>
                   {showInfo && (
-                    <div className="info">
-                      {player.club || 'Unknown'} / {player.league || 'Unknown'} /
-                      {player.nationality || 'Unknown'}
-                    </div>
+                      <ul className="info-list">
+                        <li>Club: {player.club || "Unknown"}</li>
+                        <li>League: {player.league || "Unknown"}</li>
+                        <li>Nation: {player.nationality || "Unknown"}</li>
+                        <li>Chemistry: {chemistry[rowIndex][posIndex]}</li>
+                      </ul>
                   )}
                 </>
               )}
             </div>
           ))}
         </div>
-      ))}
+      );
+      })}
       {selectedPos && (
         <div className="player-search">
           <input


### PR DESCRIPTION
## Summary
- show players from bottom (goalkeeper at end)
- display detailed info in a list along with current chemistry
- add simple styling for info list

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa22c29a0832694ef4b1138f5457c