### PR TITLE
Improve player search UI and chemistry display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -48,10 +48,11 @@ body {
   bottom: 2px;
   right: 2px;
   background: rgba(0, 0, 0, 0.6);
-  color: #fff;
+  color: #ffd700;
   font-size: 12px;
   padding: 2px 4px;
   border-radius: 4px;
+  display: flex;
 }
 
 .player-name {
@@ -89,18 +90,22 @@ body {
   margin-bottom: 10px;
 }
 
-.player-search ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+
+.suggestions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
 }
 
-.player-search li {
-  padding: 5px 0;
+.suggestion-card {
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
   cursor: pointer;
+  text-align: center;
 }
 
-.player-search li:hover {
+.suggestion-card:hover {
   background: #eee;
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -109,7 +109,8 @@ function App() {
               >
                 {player && (
                   <div className="chem-badge">
-                    {chemistry[rowIndex][posIndex]}
+                    {'\u2605'.repeat(chemistry[rowIndex][posIndex])}
+                    {'\u2606'.repeat(3 - chemistry[rowIndex][posIndex])}
                   </div>
                 )}
                 {!player && '+'}
@@ -142,16 +143,20 @@ function App() {
           />
           {loading && <div>Loading...</div>}
           {!loading && (
-            <ul>
+            <div className="suggestions-grid">
               {suggestions.map((name) => (
-                <li key={name} onClick={() => handleSelect(name)}>
+                <div
+                  className="suggestion-card"
+                  key={name}
+                  onClick={() => handleSelect(name)}
+                >
                   {name}
-                </li>
+                </div>
               ))}
               {suggestions.length === 0 && debouncedQuery.trim() !== '' && (
-                <li>No players found</li>
+                <div className="suggestion-card no-results">No players found</div>
               )}
-            </ul>
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- add star-based chemistry display
- replace list search results with a grid of cards
- update styles for star badge and suggestions grid

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fb4ac5e7c8326ba2118b9d1a0544c