### PR TITLE
Center chemistry star and polish info display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -45,14 +45,19 @@ body {
 
 .chem-badge {
   position: absolute;
-  bottom: 2px;
-  right: 2px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: rgba(0, 0, 0, 0.6);
   color: #ffd700;
-  font-size: 12px;
-  padding: 2px 4px;
-  border-radius: 4px;
+  font-size: 18px;
+  padding: 4px;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
   display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .player-name {
@@ -111,16 +116,26 @@ body {
 
 .toggle-info {
   margin: 0 auto 10px auto;
-  padding: 5px 10px;
+  padding: 6px 14px;
+  background: #0044cc;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
 }
 
 .info-list {
   font-size: 12px;
   margin: 4px 0;
-  padding-left: 16px;
+  padding: 6px 8px;
+  list-style: none;
   text-align: left;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 4px;
 }
 
 .info-list li {
   margin: 2px 0;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- center the chemistry star overlay and enlarge it for better visibility
- restyle the info button
- improve the styling of player info popup

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc830f14483268f1273df4a2667c3