### PR TITLE
Adjust chemistry badge position and info formatting

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -45,9 +45,9 @@ body {
 
 .chem-badge {
   position: absolute;
-  top: 50%;
+  top: 4px;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.6);
   color: #ffd700;
   font-size: 18px;
@@ -138,4 +138,5 @@ body {
 .info-list li {
   margin: 2px 0;
   color: #fff;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- move star (chemistry badge) to the top of player image
- keep player info items on one line using `white-space: nowrap`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fc9a6f1808326a51747031a8f263c