### PR TITLE
Add formation selection start page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,13 +4,12 @@ import './App.css';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
 
-function App() {
-  const formation = [1, 4, 4, 2];
+function App({ formation = [1, 4, 4, 2] }) {
   const [players, setPlayers] = useState(
-    formation.map(count => Array(count).fill(null))
+    formation.map((count) => Array(count).fill(null))
   );
   const [chemistry, setChemistry] = useState(
-    formation.map(count => Array(count).fill(0))
+    formation.map((count) => Array(count).fill(0))
   );
   const [totalChem, setTotalChem] = useState(0);
   const [selectedPos, setSelectedPos] = useState(null);
@@ -22,6 +21,12 @@ function App() {
   const debouncedQuery = useDebounce(query, 300);
 
   const displayRows = players.slice().reverse();
+
+  // Reset player grid if the formation prop changes
+  useEffect(() => {
+    setPlayers(formation.map((c) => Array(c).fill(null)));
+    setChemistry(formation.map((c) => Array(c).fill(0)));
+  }, [formation]);
 
   const handleAddPlayer = (row, index) => {
     setSelectedPos({ row, index });

--- a/frontend/src/StartPage.css
+++ b/frontend/src/StartPage.css
@@ -1,0 +1,57 @@
+.start-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 50px;
+  background-color: #1e7a1e;
+  height: 100vh;
+  color: #fff;
+}
+
+.formations {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.formation-option {
+  cursor: pointer;
+  padding: 10px;
+  border: 2px solid #fff;
+  border-radius: 8px;
+  width: 120px;
+  text-align: center;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.formation-option:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.formation-name {
+  margin-top: 8px;
+  font-weight: bold;
+}
+
+.formation-visual {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  height: 80px;
+}
+
+.formation-row {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  background-color: #fff;
+  border-radius: 50%;
+}

--- a/frontend/src/StartPage.js
+++ b/frontend/src/StartPage.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import './StartPage.css';
+
+const FORMATIONS = {
+  '4-4-2': [1,4,4,2],
+  '4-2-3-1': [1,4,2,3,1],
+  '3-5-2': [1,3,5,2],
+  '3-4-3': [1,3,4,3],
+  '4-3-3': [1,4,3,3]
+};
+
+function FormationVisual({ layout }) {
+  return (
+    <div className="formation-visual">
+      {layout.slice().reverse().map((count, i) => (
+        <div key={i} className="formation-row">
+          {Array.from({ length: count }).map((_, j) => (
+            <div key={j} className="dot" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function StartPage({ onSelect }) {
+  return (
+    <div className="start-page">
+      <h1>Select Formation</h1>
+      <div className="formations">
+        {Object.entries(FORMATIONS).map(([name, layout]) => (
+          <div
+            key={name}
+            className="formation-option"
+            onClick={() => onSelect(layout)}
+          >
+            <FormationVisual layout={layout} />
+            <div className="formation-name">{name}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,13 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import StartPage from './StartPage';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+
+function Root() {
+  const [formation, setFormation] = useState(null);
+
+  if (!formation) {
+    return <StartPage onSelect={setFormation} />;
+  }
+  return <App formation={formation} />;
+}
+
 root.render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add start page for choosing formation options
- reset player grid when formation changes
- show start page until lineup chosen

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcd7101f08326a9db8e21d7c4888d