### PR TITLE
Fix league list and normalize name comparisons

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,14 +38,16 @@ API_URL = "https://www.thesportsdb.com/api/v1/json/3/searchplayers.php"
 
 # Most popular leagues and teams are hard coded to avoid fetching
 # large lists from the upstream API which slowed down the app.
+# Limit leagues to those required by the frontend.  These names should
+# match exactly what the upstream API returns so that league lookups work
+# correctly.
 POPULAR_LEAGUES = [
     "Premier League",
     "La Liga",
     "Serie A",
     "Bundesliga",
     "Ligue 1",
-    "Major League Soccer",
-    "Brasileir\u00e3o",
+    "Turkish Super Lig",
     "Eredivisie",
 ]
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,17 @@ import './App.css';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
 
+// Helper to normalise strings for comparisons. Removes accents and
+// converts to lowercase so that names match API data reliably.
+const normalizeString = (str) =>
+  str
+    ? str
+        .trim()
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+    : '';
+
 // Lists of teams, leagues and nationalities are now fetched from the backend
 // instead of being hard coded.
 
@@ -171,15 +182,15 @@ function App({ formation = [1, 4, 4, 2] }) {
 
   const matchesCondition = (player) => {
     if (!selectedCondition) return true;
-    const val = selectedCondition.value.toLowerCase();
+    const val = normalizeString(selectedCondition.value);
     if (selectedCondition.type === 'club') {
-      return (player.club || '').toLowerCase() === val;
+      return normalizeString(player.club) === val;
     }
     if (selectedCondition.type === 'league') {
-      return (player.league || '').toLowerCase() === val;
+      return normalizeString(player.league) === val;
     }
     if (selectedCondition.type === 'nationality') {
-      return (player.nationality || '').toLowerCase() === val;
+      return normalizeString(player.nationality) === val;
     }
     return false;
   };

--- a/frontend/src/chemistry.js
+++ b/frontend/src/chemistry.js
@@ -3,7 +3,16 @@ export function calculateChemistry(players) {
   const leagues = {};
   const nations = {};
 
-  const norm = str => (str ? str.trim().toLowerCase() : '');
+  // Normalise strings for comparison.  This removes accents and
+  // lowercases the value so that 'Atletico' matches 'Atl\u00e9tico', etc.
+  const norm = (str) =>
+    str
+      ? str
+          .trim()
+          .toLowerCase()
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+      : '';
 
   players.flat().forEach(p => {
     if (!p) return;


### PR DESCRIPTION
## Summary
- restrict leagues to the ones requested and sync names with API
- normalize strings when comparing player club/league/nation values
- apply the same normalization when calculating chemistry

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd8523d5c83268b0138242dc5e759