### PR TITLE
Handle name mismatches

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,7 +122,7 @@ NATIONALITIES = [
     "Germany",
     "Argentina",
     "Portugal",
-    "Netherlands",
+    "The Netherlands",
     "England",
     "Belgium",
     "Croatia",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,17 +3,14 @@ import axios from 'axios';
 import './App.css';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
+import { canonicalize } from './nameUtils';
 
 // Helper to normalise strings for comparisons. Removes accents and
 // converts to lowercase so that names match API data reliably.
-const normalizeString = (str) =>
-  str
-    ? str
-        .trim()
-        .toLowerCase()
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-    : '';
+// Normalize a string for comparison against API data. Accents are removed,
+// case is lowered and any leading "The" is stripped so that user friendly
+// names like "Netherlands" match API values such as "The Netherlands".
+const normalizeString = canonicalize;
 
 // Lists of teams, leagues and nationalities are now fetched from the backend
 // instead of being hard coded.

--- a/frontend/src/chemistry.js
+++ b/frontend/src/chemistry.js
@@ -1,3 +1,5 @@
+import { canonicalize } from './nameUtils';
+
 export function calculateChemistry(players) {
   const clubs = {};
   const leagues = {};
@@ -5,14 +7,9 @@ export function calculateChemistry(players) {
 
   // Normalise strings for comparison.  This removes accents and
   // lowercases the value so that 'Atletico' matches 'Atl\u00e9tico', etc.
-  const norm = (str) =>
-    str
-      ? str
-          .trim()
-          .toLowerCase()
-          .normalize('NFD')
-          .replace(/[\u0300-\u036f]/g, '')
-      : '';
+  // Use shared canonicalisation so that values with prefixes like
+  // "The Netherlands" match "Netherlands" and accents are removed.
+  const norm = canonicalize;
 
   players.flat().forEach(p => {
     if (!p) return;

--- a/frontend/src/nameUtils.js
+++ b/frontend/src/nameUtils.js
@@ -1,0 +1,12 @@
+// Utility functions for normalizing and canonicalizing names.
+// Removes accents, converts to lowercase and strips leading articles
+// so comparisons against API data are reliable.
+export const canonicalize = (str) => {
+  if (!str) return '';
+  return str
+    .trim()
+    .toLowerCase()
+    .replace(/^the\s+/, '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+};


### PR DESCRIPTION
## Summary
- add canonicalization utility to remove accents and leading articles
- reuse canonicalization in chemistry and comparison logic
- show `The Netherlands` in nationality list

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fdfda630883268bd3122e1bf66e24