### PR TITLE
Fix team name for Serie A

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,7 +77,7 @@ POPULAR_TEAMS = {
     "Italian Serie A": [
         "Juventus",
         "AC Milan",
-        "Inter",
+        "Inter Milan",
         "Roma",
         "Lazio",
         "Napoli",


### PR DESCRIPTION
## Summary
- update team name from Inter to Inter Milan

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fe1bce6888326ab19d1b96d8c98ba