### PR TITLE
Add modal for selecting lineup conditions

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -144,23 +144,9 @@ body {
   white-space: nowrap;
 }
 
-.condition-options {
-  display: flex;
-  justify-content: center;
-  gap: 10px;
-  margin-bottom: 10px;
-}
-
-.condition-option {
-  padding: 6px 12px;
-  border: 2px solid #fff;
-  background: rgba(255, 255, 255, 0.2);
+.current-condition {
   color: #fff;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.condition-option.selected {
-  background: #fff;
-  color: #000;
+  text-align: center;
+  margin-bottom: 10px;
+  font-size: 18px;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import './App.css';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
 import { canonicalize } from './nameUtils';
+import ConditionModal from './ConditionModal';
 
 // Helper to normalise strings for comparisons. Removes accents and
 // converts to lowercase so that names match API data reliably.
@@ -63,6 +64,7 @@ function App({ formation = [1, 4, 4, 2] }) {
   const [conditionOptions, setConditionOptions] = useState([]);
   const [selectedCondition, setSelectedCondition] = useState(null);
   const [step, setStep] = useState(0);
+  const [showConditionModal, setShowConditionModal] = useState(true);
 
   // Fetch leagues and nationalities on initial load
   useEffect(() => {
@@ -108,6 +110,7 @@ function App({ formation = [1, 4, 4, 2] }) {
       setConditionOptions(
         getRandomOptions(Object.values(teamsByLeague).flat(), leagues, nations)
       );
+      setShowConditionModal(true);
     }
   }, [leagues, nations, teamsByLeague]);
 
@@ -122,6 +125,7 @@ function App({ formation = [1, 4, 4, 2] }) {
     setChemistry(formation.map((c) => Array(c).fill(0)));
     setConditionOptions(getRandomOptions(Object.values(teamsByLeague).flat(), leagues, nations));
     setSelectedCondition(null);
+    setShowConditionModal(true);
     setStep(0);
   }, [formation]);
 
@@ -129,8 +133,14 @@ function App({ formation = [1, 4, 4, 2] }) {
     if (step < totalSlots) {
       setConditionOptions(getRandomOptions(Object.values(teamsByLeague).flat(), leagues, nations));
       setSelectedCondition(null);
+      setShowConditionModal(true);
     }
   }, [step, totalSlots]);
+
+  const handleConditionSelect = (opt) => {
+    setSelectedCondition(opt);
+    setTimeout(() => setShowConditionModal(false), 500);
+  };
 
   const handleAddPlayer = (row, index) => {
     if (step >= totalSlots) return;
@@ -216,22 +226,19 @@ function App({ formation = [1, 4, 4, 2] }) {
 
   return (
     <div className="field">
+      {showConditionModal && (
+        <ConditionModal
+          options={conditionOptions}
+          onSelect={handleConditionSelect}
+          selected={selectedCondition}
+        />
+      )}
       <div className="total-chemistry">{totalChem}/33</div>
-      {step < totalSlots && (
-        <div className="condition-options">
-          {conditionOptions.map((opt, i) => (
-            <button
-              key={i}
-              className={`condition-option ${
-                selectedCondition === opt ? 'selected' : ''
-              }`}
-              onClick={() => setSelectedCondition(opt)}
-            >
-              {opt.type === 'club' && `Team: ${opt.value}`}
-              {opt.type === 'league' && `League: ${opt.value}`}
-              {opt.type === 'nationality' && `Nation: ${opt.value}`}
-            </button>
-          ))}
+      {selectedCondition && (
+        <div className="current-condition">
+          {selectedCondition.type === 'club' && `Team: ${selectedCondition.value}`}
+          {selectedCondition.type === 'league' && `League: ${selectedCondition.value}`}
+          {selectedCondition.type === 'nationality' && `Nation: ${selectedCondition.value}`}
         </div>
       )}
       <button className="toggle-info" onClick={() => setShowInfo(!showInfo)}>

--- a/frontend/src/ConditionModal.css
+++ b/frontend/src/ConditionModal.css
@@ -1,0 +1,47 @@
+.condition-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.condition-modal-content {
+  display: flex;
+  gap: 20px;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 8px;
+}
+
+.condition-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  padding: 10px;
+  border: 2px solid transparent;
+  border-radius: 6px;
+}
+
+.condition-card img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  margin-bottom: 8px;
+}
+
+.condition-card.selected {
+  border-color: #0044cc;
+  background: #e8f0ff;
+}
+
+.condition-label {
+  font-weight: bold;
+  text-align: center;
+}

--- a/frontend/src/ConditionModal.js
+++ b/frontend/src/ConditionModal.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import './ConditionModal.css';
+
+function getImageSrc(option) {
+  // Use flag images for nationalities when possible. Fallback to generic logo.
+  if (option.type === 'nationality') {
+    const code = option.value
+      .toLowerCase()
+      .replace(/[^a-z]/g, '');
+    // Attempt to fetch flag from flagcdn. This may fail silently if offline.
+    return `https://flagcdn.com/w80/${code}.png`;
+  }
+  // For club and league use the default React logo as placeholder.
+  return '/logo192.png';
+}
+
+export default function ConditionModal({ options, onSelect, selected }) {
+  return (
+    <div className="condition-modal">
+      <div className="condition-modal-content">
+        {options.map((opt, i) => (
+          <div
+            key={i}
+            className={`condition-card ${selected === opt ? 'selected' : ''}`}
+            onClick={() => onSelect(opt)}
+          >
+            <img src={getImageSrc(opt)} alt={opt.value} />
+            <div className="condition-label">
+              {opt.type === 'club' && `Team: ${opt.value}`}
+              {opt.type === 'league' && `League: ${opt.value}`}
+              {opt.type === 'nationality' && `Nation: ${opt.value}`}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ConditionModal` component for centralized condition selection
- dim background when choosing conditions and highlight selected choice
- show currently selected condition above the lineup

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685feb9dee648326b1552aa5032cd5ea