### PR TITLE
Fix incorrect logos in condition modal

### DIFF
--- a/frontend/src/ConditionModal.js
+++ b/frontend/src/ConditionModal.js
@@ -86,9 +86,9 @@ export default function ConditionModal({ options, onSelect, selected }) {
   return (
     <div className="condition-modal">
       <div className="condition-modal-content">
-        {options.map((opt, i) => (
+        {options.map((opt) => (
           <div
-            key={i}
+            key={`${opt.type}-${canonicalize(opt.value)}`}
             className={`condition-card ${selected === opt ? 'selected' : ''}`}
             onClick={() => onSelect(opt)}
           >


### PR DESCRIPTION
## Summary
- ensure each condition card has a unique React `key`

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff2091184832680422226f30c5b4d