### PR TITLE
Enable editing of selected conditions

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -134,9 +134,7 @@ function App({ formation = [1, 4, 4, 2] }) {
   }, [step, totalSlots]);
 
   const handleConditionSelect = (opt) => {
-    if (!selectedCondition) {
-      setSelectedCondition(opt);
-    }
+    setSelectedCondition(opt);
   };
 
   const handleAddPlayer = (row, index) => {

--- a/frontend/src/ConditionBar.css
+++ b/frontend/src/ConditionBar.css
@@ -28,11 +28,6 @@
   background: #e8f0ff;
 }
 
-.condition-card.disabled {
-  opacity: 0.5;
-  pointer-events: none;
-}
-
 .condition-label {
   font-weight: bold;
   text-align: center;

--- a/frontend/src/ConditionBar.js
+++ b/frontend/src/ConditionBar.js
@@ -86,12 +86,13 @@ export default function ConditionBar({ options, onSelect, selected }) {
   return (
     <div className="condition-bar">
       {options.map((opt) => {
-        const isSelected = selected && selected.type === opt.type && selected.value === opt.value;
+        const isSelected =
+          selected && selected.type === opt.type && selected.value === opt.value;
         return (
           <div
             key={`${opt.type}-${canonicalize(opt.value)}`}
-            className={`condition-card ${isSelected ? 'selected' : ''} ${selected && !isSelected ? 'disabled' : ''}`}
-            onClick={() => (!selected ? onSelect(opt) : undefined)}
+            className={`condition-card ${isSelected ? 'selected' : ''}`}
+            onClick={() => onSelect(opt)}
           >
             <Logo option={opt} />
             <div className="condition-label">


### PR DESCRIPTION
## Summary
- allow toggling the active condition in the condition bar
- remove disabled styles from the condition bar
- simplify condition selection logic in App

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff503d6988326a8feac67752f2bbf