### PR TITLE
Add fallback data for condition options

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,11 @@ import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
 import { canonicalize } from './nameUtils';
 import ConditionBar from './ConditionBar';
+import {
+  DEFAULT_LEAGUES,
+  DEFAULT_TEAMS,
+  DEFAULT_NATIONALITIES,
+} from './fallbackData';
 
 // Helper to normalise strings for comparisons. Removes accents and
 // converts to lowercase so that names match API data reliably.
@@ -73,10 +78,12 @@ function App({ formation = [1, 4, 4, 2] }) {
           axios.get('http://localhost:8000/leagues'),
           axios.get('http://localhost:8000/nationalities'),
         ]);
-        setLeagues(leaguesRes.data.leagues || []);
-        setNations(nationsRes.data.nationalities || []);
+        setLeagues(leaguesRes.data.leagues || DEFAULT_LEAGUES);
+        setNations(nationsRes.data.nationalities || DEFAULT_NATIONALITIES);
       } catch (err) {
         console.error(err);
+        setLeagues(DEFAULT_LEAGUES);
+        setNations(DEFAULT_NATIONALITIES);
       }
     };
     fetchMeta();
@@ -91,9 +98,10 @@ function App({ formation = [1, 4, 4, 2] }) {
           const res = await axios.get('http://localhost:8000/teams', {
             params: { league: lg },
           });
-          dict[lg] = res.data.teams || [];
+          dict[lg] = res.data.teams || DEFAULT_TEAMS[lg] || [];
         } catch (err) {
           console.error(err);
+          dict[lg] = DEFAULT_TEAMS[lg] || [];
         }
       }
       setTeamsByLeague(dict);

--- a/frontend/src/MultiPlayerGame.js
+++ b/frontend/src/MultiPlayerGame.js
@@ -4,6 +4,11 @@ import ConditionBar from './ConditionBar';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
 import { canonicalize } from './nameUtils';
+import {
+  DEFAULT_LEAGUES,
+  DEFAULT_TEAMS,
+  DEFAULT_NATIONALITIES,
+} from './fallbackData';
 import './App.css';
 
 function getRandomOptions(teams, leagues, nations) {
@@ -53,10 +58,12 @@ export default function MultiPlayerGame({ formation, players }) {
           axios.get('http://localhost:8000/leagues'),
           axios.get('http://localhost:8000/nationalities'),
         ]);
-        setLeagues(leaguesRes.data.leagues || []);
-        setNations(nationsRes.data.nationalities || []);
+        setLeagues(leaguesRes.data.leagues || DEFAULT_LEAGUES);
+        setNations(nationsRes.data.nationalities || DEFAULT_NATIONALITIES);
       } catch (err) {
         console.error(err);
+        setLeagues(DEFAULT_LEAGUES);
+        setNations(DEFAULT_NATIONALITIES);
       }
     };
     fetchMeta();
@@ -68,9 +75,10 @@ export default function MultiPlayerGame({ formation, players }) {
       for (const lg of leagues) {
         try {
           const res = await axios.get('http://localhost:8000/teams', { params: { league: lg } });
-          dict[lg] = res.data.teams || [];
+          dict[lg] = res.data.teams || DEFAULT_TEAMS[lg] || [];
         } catch (err) {
           console.error(err);
+          dict[lg] = DEFAULT_TEAMS[lg] || [];
         }
       }
       setTeamsByLeague(dict);

--- a/frontend/src/fallbackData.js
+++ b/frontend/src/fallbackData.js
@@ -1,0 +1,89 @@
+export const DEFAULT_LEAGUES = [
+  'English Premier League',
+  'Spanish La Liga',
+  'Italian Serie A',
+  'German Bundesliga',
+  'French Ligue 1'
+];
+
+export const DEFAULT_TEAMS = {
+  'English Premier League': [
+    'Arsenal',
+    'Chelsea',
+    'Liverpool',
+    'Manchester City',
+    'Manchester United',
+    'Tottenham',
+    'Newcastle',
+    'Everton',
+    'Aston Villa',
+    'Leeds'
+  ],
+  'Spanish La Liga': [
+    'Real Madrid',
+    'Barcelona',
+    'Atlético Madrid',
+    'Sevilla',
+    'Valencia',
+    'Villarreal',
+    'Real Sociedad',
+    'Athletic Bilbao',
+    'Real Betis',
+    'Celta Vigo'
+  ],
+  'Italian Serie A': [
+    'Juventus',
+    'AC Milan',
+    'Inter',
+    'Roma',
+    'Lazio',
+    'Napoli',
+    'Fiorentina',
+    'Atalanta',
+    'Torino',
+    'Sampdoria'
+  ],
+  'German Bundesliga': [
+    'Bayern Munich',
+    'Borussia Dortmund',
+    'RB Leipzig',
+    'Bayer Leverkusen',
+    'Schalke 04',
+    'VfL Wolfsburg',
+    'Borussia Mönchengladbach',
+    'Eintracht Frankfurt',
+    'Hertha Berlin',
+    'Werder Bremen'
+  ],
+  'French Ligue 1': [
+    'Paris Saint-Germain',
+    'Marseille',
+    'Lyon',
+    'Monaco',
+    'Lille',
+    'Nice',
+    'Rennes',
+    'Bordeaux',
+    'Saint-Étienne',
+    'Nantes'
+  ]
+};
+
+export const DEFAULT_NATIONALITIES = [
+  'Brazil',
+  'Spain',
+  'Italy',
+  'France',
+  'Germany',
+  'Argentina',
+  'Portugal',
+  'The Netherlands',
+  'England',
+  'Belgium',
+  'Croatia',
+  'Uruguay',
+  'Mexico',
+  'United States',
+  'Japan',
+  'South Korea'
+];


### PR DESCRIPTION
## Summary
- provide hardcoded fallback leagues, teams and nationalities
- use fallback data in single and multiplayer modes when backend requests fail

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffdabe2208326b418a7e3582f5ff5