### PR TITLE
Fix condition modal display

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
 import { canonicalize } from './nameUtils';
 import ConditionBar from './ConditionBar';
+import ConditionModal from './ConditionModal';
 import {
   DEFAULT_LEAGUES,
   DEFAULT_TEAMS,
@@ -229,6 +230,13 @@ function App({ formation = [1, 4, 4, 2] }) {
 
   return (
     <div className="field">
+      {!selectedCondition && step < totalSlots && (
+        <ConditionModal
+          options={conditionOptions}
+          onSelect={handleConditionSelect}
+          selected={selectedCondition}
+        />
+      )}
       <ConditionBar
         options={conditionOptions}
         onSelect={handleConditionSelect}

--- a/frontend/src/MultiPlayerGame.js
+++ b/frontend/src/MultiPlayerGame.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import ConditionBar from './ConditionBar';
+import ConditionModal from './ConditionModal';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
 import { canonicalize } from './nameUtils';
@@ -199,8 +200,17 @@ export default function MultiPlayerGame({ formation, players }) {
   return (
     <div className="field">
       {!selectedCondition && currentPlayer === pickerIndex && (
-        <ConditionBar options={conditionOptions} onSelect={handleConditionSelect} selected={selectedCondition} />
+        <ConditionModal
+          options={conditionOptions}
+          onSelect={handleConditionSelect}
+          selected={selectedCondition}
+        />
       )}
+      <ConditionBar
+        options={conditionOptions}
+        onSelect={handleConditionSelect}
+        selected={selectedCondition}
+      />
       {selectedCondition && (
         <div className="current-condition">
           Player {players[currentPlayer]} - {selectedCondition.type}: {selectedCondition.value}


### PR DESCRIPTION
## Summary
- show the condition selection modal before picking players in both modes

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fff50851c8326ba444929cf543397