### PR TITLE
Make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# LineupDraft
+
+This project contains a React frontend and a FastAPI backend. By default the frontend expects the API server to run on `http://localhost:8000`. To deploy the application publicly you can build the frontend and host it on a static hosting provider and run the backend on any cloud service.
+
+## Building the frontend
+
+```
+cd frontend
+npm install
+npm run build
+```
+
+The production files will be located in `frontend/build`. You can deploy this directory to services like Netlify, Vercel or any static web host.
+
+Set the API base URL by defining `REACT_APP_API_URL` before building or in an `.env` file. See `.env.example` for a template.
+
+## Running the backend
+
+```
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Deploy the backend using a provider that supports Python web services (e.g. Render, DigitalOcean, Railway).
+
+Ensure the `REACT_APP_API_URL` in the frontend points to the public URL of your backend.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8000

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+const API_BASE_URL = process.env.REACT_APP_API_URL || '';
 import './App.css';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
@@ -70,8 +71,8 @@ function App({ formation = [1, 4, 4, 2] }) {
     const fetchMeta = async () => {
       try {
         const [leaguesRes, nationsRes] = await Promise.all([
-          axios.get('http://localhost:8000/leagues'),
-          axios.get('http://localhost:8000/nationalities'),
+          axios.get(`${API_BASE_URL}/leagues`),
+          axios.get(`${API_BASE_URL}/nationalities`),
         ]);
         setLeagues(leaguesRes.data.leagues || []);
         setNations(nationsRes.data.nationalities || []);
@@ -88,7 +89,7 @@ function App({ formation = [1, 4, 4, 2] }) {
       const dict = {};
       for (const lg of leagues) {
         try {
-          const res = await axios.get('http://localhost:8000/teams', {
+          const res = await axios.get(`${API_BASE_URL}/teams`, {
             params: { league: lg },
           });
           dict[lg] = res.data.teams || [];
@@ -157,7 +158,7 @@ function App({ formation = [1, 4, 4, 2] }) {
       }
       setLoading(true);
       try {
-        const res = await axios.get('http://localhost:8000/players', {
+        const res = await axios.get(`${API_BASE_URL}/players`, {
           params: { search: debouncedQuery }
         });
         if (cancel) return;
@@ -200,7 +201,7 @@ function App({ formation = [1, 4, 4, 2] }) {
   const handleSelect = async (name) => {
     if (!selectedPos) return;
     try {
-      const res = await axios.get('http://localhost:8000/player', {
+      const res = await axios.get(`${API_BASE_URL}/player`, {
         params: { name }
       });
       if (!matchesCondition(res.data)) {

--- a/frontend/src/MultiPlayerGame.js
+++ b/frontend/src/MultiPlayerGame.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+const API_BASE_URL = process.env.REACT_APP_API_URL || '';
 import ConditionBar from './ConditionBar';
 import { calculateChemistry } from './chemistry';
 import useDebounce from './useDebounce';
@@ -50,8 +51,8 @@ export default function MultiPlayerGame({ formation, players }) {
     const fetchMeta = async () => {
       try {
         const [leaguesRes, nationsRes] = await Promise.all([
-          axios.get('http://localhost:8000/leagues'),
-          axios.get('http://localhost:8000/nationalities'),
+          axios.get(`${API_BASE_URL}/leagues`),
+          axios.get(`${API_BASE_URL}/nationalities`),
         ]);
         setLeagues(leaguesRes.data.leagues || []);
         setNations(nationsRes.data.nationalities || []);
@@ -67,7 +68,7 @@ export default function MultiPlayerGame({ formation, players }) {
       const dict = {};
       for (const lg of leagues) {
         try {
-          const res = await axios.get('http://localhost:8000/teams', { params: { league: lg } });
+          const res = await axios.get(`${API_BASE_URL}/teams`, { params: { league: lg } });
           dict[lg] = res.data.teams || [];
         } catch (err) {
           console.error(err);
@@ -97,7 +98,7 @@ export default function MultiPlayerGame({ formation, players }) {
     const fetchPlayers = async () => {
       setLoading(true);
       try {
-        const res = await axios.get('http://localhost:8000/players', { params: { search: debouncedQuery } });
+        const res = await axios.get(`${API_BASE_URL}/players`, { params: { search: debouncedQuery } });
         if (cancel) return;
         const used = usedPlayers;
         const available = res.data.players.filter((name) => !used.includes(name));
@@ -150,7 +151,7 @@ export default function MultiPlayerGame({ formation, players }) {
   const handleSelect = async (name) => {
     if (!selectedPos) return;
     try {
-      const res = await axios.get('http://localhost:8000/player', { params: { name } });
+      const res = await axios.get(`${API_BASE_URL}/player`, { params: { name } });
       if (!matchesCondition(res.data)) {
         alert('Player does not match the selected condition');
         return;


### PR DESCRIPTION
## Summary
- configure React code to use `REACT_APP_API_URL`
- add `.env.example`
- document deployment steps in README

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e516422c8326aa376d08afc85118