### PR TITLE
Optimize condition bar for mobile

### DIFF
--- a/frontend/src/ConditionBar.css
+++ b/frontend/src/ConditionBar.css
@@ -3,6 +3,7 @@
   justify-content: center;
   gap: 20px;
   margin-bottom: 10px;
+  flex-wrap: wrap;
 }
 
 .condition-card {
@@ -31,4 +32,24 @@
 .condition-label {
   font-weight: bold;
   text-align: center;
+}
+
+@media (max-width: 480px) {
+  .condition-bar {
+    gap: 8px;
+  }
+
+  .condition-card {
+    padding: 6px;
+  }
+
+  .condition-card img {
+    width: 40px;
+    height: 40px;
+    margin-bottom: 4px;
+  }
+
+  .condition-label {
+    font-size: 12px;
+  }
 }

--- a/frontend/src/ConditionBar.js
+++ b/frontend/src/ConditionBar.js
@@ -12,7 +12,8 @@ function Logo({ option }) {
         const code = option.value
           .toLowerCase()
           .replace(/[^a-z]/g, '');
-        setSrc(`https://flagcdn.com/w80/${code}.png`);
+        // Load a smaller flag icon for better mobile performance
+        setSrc(`https://flagcdn.com/w40/${code}.png`);
         return;
       }
 


### PR DESCRIPTION
## Summary
- make condition bar wrap on small screens
- add media query for compact layout
- load smaller flag images for better mobile performance

## Testing
- `npm test -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ee2496f48326826e2f3a89db0a1e