### PR TITLE
Fix info list overlap

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -25,6 +25,7 @@ body {
   width: 80px;
   color: #fff;
   text-align: center;
+  position: relative;
 }
 
 .position {
@@ -136,6 +137,11 @@ body {
   text-align: left;
   background: rgba(0, 0, 0, 0.6);
   border-radius: 4px;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
 }
 
 .info-list li {


### PR DESCRIPTION
## Summary
- prevent overlapping info cards when 'Show info' is used

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f2ba11f48326a2344f4d9ec18867